### PR TITLE
feat: Add GH Actions for Pytest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install jax-fid
+          pip install "jax-fid[testing]"
       - name: Test with PyTest
         run: |
           pytest -v .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,34 @@
+name: "Build and Tests"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ created ]
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install jax-fid
+      - name: Test with PyTest
+        run: |
+          pytest -v .

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install --upgrade pip wheel setuptools pyyaml
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install "jax-fid[testing]"
       - name: Test with PyTest


### PR DESCRIPTION
Adds a simple Github Actions Workflow to install `jax-fid` and run `pytest` on every push, PR, release and once a week.

Apologies for the multiple commits, might I suggest a Squash and Merge commit instead of a rebase. As a side note using standard installation procedures on new machines, the tests and installation fail on python versions 3.6, 3.7 and 3.10. 

Successful Logs and Failed tests as proof for python version 3.6, 3.7 and 3.10 can be found on my [**fork**](https://github.com/SauravMaheshkar/jax-fid/pull/1)